### PR TITLE
feat: add bussiness-alert

### DIFF
--- a/dist/commbot-commands-types.d.ts
+++ b/dist/commbot-commands-types.d.ts
@@ -79,7 +79,8 @@ export declare namespace Commbot {
     "GHOSTOFMANUEL_PR_REMINDER",
     "RUN_E2E_TESTS_SUCCESS",
     "RUN_E2E_TESTS_FAILURE",
-    "QDB2_FAIL_ALERT"
+    "QDB2_FAIL_ALERT",
+    "BUSINESS_ALERT"
   ];
   type TWithOrigSlackMsg = {
     slackMessageTs: string;
@@ -304,6 +305,11 @@ export declare namespace Commbot {
     QDB2_FAIL_ALERT: TWithRegionAndDataEnv & {
       errorMessage: string;
       qdb2Name: string;
+    };
+    BUSINESS_ALERT: TWithRegionAndDataEnv & {
+      channel?: string;
+      scenario: string;
+      data: Record<string, string>;
     };
   }
   type TCommbotCommandTypes = typeof commbotCommands;

--- a/dist/commbot-commands-types.js
+++ b/dist/commbot-commands-types.js
@@ -62,6 +62,7 @@ var Commbot;
         "RUN_E2E_TESTS_SUCCESS",
         "RUN_E2E_TESTS_FAILURE",
         "QDB2_FAIL_ALERT",
+        "BUSINESS_ALERT",
     ];
     Commbot.isCommbotCommand = (thing) => !!thing &&
         !!thing.internalCommand &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commbot-shared-types",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/commbot-commands-types.ts
+++ b/src/commbot-commands-types.ts
@@ -92,6 +92,8 @@ export namespace Commbot {
     "RUN_E2E_TESTS_FAILURE",
 
     "QDB2_FAIL_ALERT",
+
+    "BUSINESS_ALERT",
   ] as const;
 
   type TWithOrigSlackMsg = {
@@ -367,6 +369,12 @@ export namespace Commbot {
     QDB2_FAIL_ALERT: TWithRegionAndDataEnv & {
       errorMessage: string;
       qdb2Name: string;
+    };
+
+    BUSINESS_ALERT: TWithRegionAndDataEnv & {
+      channel?: string;
+      scenario: string;
+      data: Record<string, string>;
     };
   }
 


### PR DESCRIPTION
## Summary
- Add a new `BUSINESS_ALERT` command type with `channel`, `scenario`, and `data` fields
- Bump package version to 2.0.2

## Test plan
- [ ] Verify `BUSINESS_ALERT` type shape matches expected payload from producer
- [ ] Confirm consumers can import and use the new type without breaking changes